### PR TITLE
Don't require `UsbPeripheral` to be `Sync`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub use usbd::Usbd;
 /// A trait for device-specific USB peripherals. Implement this to add support for a new hardware
 /// platform. Peripherals that have this trait must have the same register block as NRF52 USBD
 /// peripherals.
-pub unsafe trait UsbPeripheral: Send + Sync {
+pub unsafe trait UsbPeripheral: Send {
     /// Pointer to the register block
     const REGISTERS: *const ();
 }


### PR DESCRIPTION
It's stored in a `Mutex`, which turns `Send` data `Sync`, so this trait bound shouldn't be required.