### PR TITLE
Add enable/disable interrupt helper functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,11 @@ mod errata;
 mod pac;
 mod usbd;
 
-pub use usbd::Usbd;
+pub use usbd::{
+    Usbd,
+    disable_usb_interrupts,
+    enable_usb_interrupts,
+};
 
 /// A trait for device-specific USB peripherals. Implement this to add support for a new hardware
 /// platform. Peripherals that have this trait must have the same register block as NRF52 USBD

--- a/src/usbd.rs
+++ b/src/usbd.rs
@@ -742,3 +742,83 @@ impl<T: UsbPeripheral> UsbBus for Usbd<T> {
         Ok(())
     }
 }
+
+/// Enable USB event interrupts used by [Usbd]
+///
+/// This must be done with a borrow of the USBD peripheral, prior to
+/// calling the [Usbd::new()] constructor.
+///
+/// This only enables the events of the USBD peripheral, you will
+/// Also need to activate the USBD interrupt in the NVIC. This is
+/// handled automatically if you are using RTIC with a hardware
+/// bound task.
+pub fn enable_usb_interrupts<T: UsbPeripheral>(usbd: &T) {
+    let usbd = unsafe { &*(T::REGISTERS as *const RegisterBlock) };
+
+    usbd.intenset.write(|w| {
+        // rg -o "events_[a-z_0-9]+" ./usbd.rs | sort | uniq
+        w.endepin0().set_bit();
+        w.endepin1().set_bit();
+        w.endepin2().set_bit();
+        w.endepin3().set_bit();
+        w.endepin4().set_bit();
+        w.endepin5().set_bit();
+        w.endepin6().set_bit();
+        w.endepin7().set_bit();
+
+        w.endepout0().set_bit();
+        w.endepout1().set_bit();
+        w.endepout2().set_bit();
+        w.endepout3().set_bit();
+        w.endepout4().set_bit();
+        w.endepout5().set_bit();
+        w.endepout6().set_bit();
+        w.endepout7().set_bit();
+
+        w.ep0datadone().set_bit();
+        w.ep0setup().set_bit();
+        w.sof().set_bit();
+        w.usbevent().set_bit();
+        w.usbreset().set_bit();
+        w
+    });
+}
+
+/// Disable USB event interrupts used by [Usbd]
+///
+/// This must be done with a borrow of the USBD peripheral. This may
+/// require unsafe code to obtain, after the creation of [Usbd]
+///
+/// This only disables the events of the USBD peripheral, you will
+/// also need to deactivate the USBD interrupt in the NVIC.
+pub fn disable_usb_interrupts<T: UsbPeripheral>(usbd: &T) {
+    let usbd = unsafe { &*(T::REGISTERS as *const RegisterBlock) };
+
+    usbd.intenclr.write(|w| {
+        // rg -o "events_[a-z_0-9]+" ./usbd.rs | sort | uniq
+        w.endepin0().set_bit();
+        w.endepin1().set_bit();
+        w.endepin2().set_bit();
+        w.endepin3().set_bit();
+        w.endepin4().set_bit();
+        w.endepin5().set_bit();
+        w.endepin6().set_bit();
+        w.endepin7().set_bit();
+
+        w.endepout0().set_bit();
+        w.endepout1().set_bit();
+        w.endepout2().set_bit();
+        w.endepout3().set_bit();
+        w.endepout4().set_bit();
+        w.endepout5().set_bit();
+        w.endepout6().set_bit();
+        w.endepout7().set_bit();
+
+        w.ep0datadone().set_bit();
+        w.ep0setup().set_bit();
+        w.sof().set_bit();
+        w.usbevent().set_bit();
+        w.usbreset().set_bit();
+        w
+    });
+}


### PR DESCRIPTION
As mentioned on matrix, I wanted to switch from regular polling to interrupt driving of the USB handler.

This interface is awkward, because `Usbd` returns a `BusAllocator`, which really gives no way (I can see?) to take access to the relevant USBD peripheral.

Additionally, we *probably* should only enable endpoint interrupts (`endepin*` and `endepout*`) that we are actually using (so enable them on allocation), but I would hope they wouldn't fire if the endpoint isn't being used?

Feel free to reject this if it's too "funky", but I ended up writing these for my own project, and they seem to work well.