### PR TITLE
Update to critical-section 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ repository = "https://github.com/nrf-rs/nrf-usbd"
 cortex-m = "0.7.2"
 usb-device = "0.2.8"
 vcell = "0.1.3"
-critical-section = "0.2.4"
-bare-metal = "1.0.0"
+critical-section = "1.0.0"
 
 [profile.dev]
 codegen-units = 1

--- a/src/usbd.rs
+++ b/src/usbd.rs
@@ -6,11 +6,10 @@
 //!   * Different events are used to initiate transfers.
 //!   * No notification when the status stage is ACK'd.
 
-use bare_metal::Mutex;
 use core::cell::Cell;
 use core::mem::MaybeUninit;
 use core::sync::atomic::{compiler_fence, Ordering};
-use critical_section::CriticalSection;
+use critical_section::{CriticalSection, Mutex};
 use usb_device::{
     bus::{PollResult, UsbBus, UsbBusAllocator},
     endpoint::{EndpointAddress, EndpointType},


### PR DESCRIPTION
This is a breaking change, because 1.0 no longer supplies any critical section implementation by default. The user has to opt-in to one instead (for example, by enabling the `critical-section-single-core` feature in `cortex-m`: https://github.com/rust-embedded/cortex-m/pull/447#issuecomment-1210935188).

TODO before merging:

- [x] Wait for `critical-section 1.0` release https://github.com/rust-embedded/critical-section/pull/19