### PR TITLE
Return `Self` from `Usbd::new`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,6 @@
 [workspace]
-members = [
-    ".",
-    "example",
-]
+members = [".", "example"]
+default-members = [".", "example"]
 
 [package]
 name = "nrf-usbd"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -5,6 +5,7 @@ use defmt_rtt as _;
 use nrf_usbd::{UsbPeripheral, Usbd};
 // global logger
 use panic_probe as _;
+use usb_device::class_prelude::UsbBusAllocator;
 
 use core::str;
 use core::sync::atomic::{AtomicUsize, Ordering};
@@ -40,7 +41,7 @@ fn main() -> ! {
 
     info!("starting...");
 
-    let usb_bus = Usbd::new(Peripheral);
+    let usb_bus = UsbBusAllocator::new(Usbd::new(Peripheral));
     let mut serial = SerialPort::new(&usb_bus);
 
     let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))


### PR DESCRIPTION
This makes the `device_address` method usable, and allows adding more methods in the future (although they'll only work before the bus is initialized).

Also build/check the example by default.

cc https://github.com/nrf-rs/nrf-usbd/pull/8