### PR TITLE
Fix mismatched_lifetime_syntaxes lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! USB peripheral driver for nRF microcontrollers.
 
 #![no_std]
-#![allow(mismatched_lifetime_syntaxes)] // TODO: Remove in follow-up PR.
 
 mod errata;
 mod pac;

--- a/src/pac/usbd/dpdmvalue.rs
+++ b/src/pac/usbd/dpdmvalue.rs
@@ -99,7 +99,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:4 - State D+ and D- lines will be forced into by the DPDMDRIVE task"]
     #[inline(always)]
-    pub fn state(&mut self) -> STATE_W {
+    pub fn state(&mut self) -> STATE_W<'_> {
         STATE_W { w: self }
     }
 }

--- a/src/pac/usbd/dtoggle.rs
+++ b/src/pac/usbd/dtoggle.rs
@@ -198,17 +198,17 @@ impl R {
 impl W {
     #[doc = "Bits 0:2 - Select bulk endpoint number"]
     #[inline(always)]
-    pub fn ep(&mut self) -> EP_W {
+    pub fn ep(&mut self) -> EP_W<'_> {
         EP_W { w: self }
     }
     #[doc = "Bit 7 - Selects IN or OUT endpoint"]
     #[inline(always)]
-    pub fn io(&mut self) -> IO_W {
+    pub fn io(&mut self) -> IO_W<'_> {
         IO_W { w: self }
     }
     #[doc = "Bits 8:9 - Data toggle value"]
     #[inline(always)]
-    pub fn value(&mut self) -> VALUE_W {
+    pub fn value(&mut self) -> VALUE_W<'_> {
         VALUE_W { w: self }
     }
 }

--- a/src/pac/usbd/enable.rs
+++ b/src/pac/usbd/enable.rs
@@ -95,7 +95,7 @@ impl R {
 impl W {
     #[doc = "Bit 0 - Enable USB"]
     #[inline(always)]
-    pub fn enable(&mut self) -> ENABLE_W {
+    pub fn enable(&mut self) -> ENABLE_W<'_> {
         ENABLE_W { w: self }
     }
 }

--- a/src/pac/usbd/epdatastatus.rs
+++ b/src/pac/usbd/epdatastatus.rs
@@ -1135,72 +1135,72 @@ impl R {
 impl W {
     #[doc = "Bit 1 - Acknowledged data transfer on this IN endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin1(&mut self) -> EPIN1_W {
+    pub fn epin1(&mut self) -> EPIN1_W<'_> {
         EPIN1_W { w: self }
     }
     #[doc = "Bit 2 - Acknowledged data transfer on this IN endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin2(&mut self) -> EPIN2_W {
+    pub fn epin2(&mut self) -> EPIN2_W<'_> {
         EPIN2_W { w: self }
     }
     #[doc = "Bit 3 - Acknowledged data transfer on this IN endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin3(&mut self) -> EPIN3_W {
+    pub fn epin3(&mut self) -> EPIN3_W<'_> {
         EPIN3_W { w: self }
     }
     #[doc = "Bit 4 - Acknowledged data transfer on this IN endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin4(&mut self) -> EPIN4_W {
+    pub fn epin4(&mut self) -> EPIN4_W<'_> {
         EPIN4_W { w: self }
     }
     #[doc = "Bit 5 - Acknowledged data transfer on this IN endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin5(&mut self) -> EPIN5_W {
+    pub fn epin5(&mut self) -> EPIN5_W<'_> {
         EPIN5_W { w: self }
     }
     #[doc = "Bit 6 - Acknowledged data transfer on this IN endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin6(&mut self) -> EPIN6_W {
+    pub fn epin6(&mut self) -> EPIN6_W<'_> {
         EPIN6_W { w: self }
     }
     #[doc = "Bit 7 - Acknowledged data transfer on this IN endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin7(&mut self) -> EPIN7_W {
+    pub fn epin7(&mut self) -> EPIN7_W<'_> {
         EPIN7_W { w: self }
     }
     #[doc = "Bit 17 - Acknowledged data transfer on this OUT endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout1(&mut self) -> EPOUT1_W {
+    pub fn epout1(&mut self) -> EPOUT1_W<'_> {
         EPOUT1_W { w: self }
     }
     #[doc = "Bit 18 - Acknowledged data transfer on this OUT endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout2(&mut self) -> EPOUT2_W {
+    pub fn epout2(&mut self) -> EPOUT2_W<'_> {
         EPOUT2_W { w: self }
     }
     #[doc = "Bit 19 - Acknowledged data transfer on this OUT endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout3(&mut self) -> EPOUT3_W {
+    pub fn epout3(&mut self) -> EPOUT3_W<'_> {
         EPOUT3_W { w: self }
     }
     #[doc = "Bit 20 - Acknowledged data transfer on this OUT endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout4(&mut self) -> EPOUT4_W {
+    pub fn epout4(&mut self) -> EPOUT4_W<'_> {
         EPOUT4_W { w: self }
     }
     #[doc = "Bit 21 - Acknowledged data transfer on this OUT endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout5(&mut self) -> EPOUT5_W {
+    pub fn epout5(&mut self) -> EPOUT5_W<'_> {
         EPOUT5_W { w: self }
     }
     #[doc = "Bit 22 - Acknowledged data transfer on this OUT endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout6(&mut self) -> EPOUT6_W {
+    pub fn epout6(&mut self) -> EPOUT6_W<'_> {
         EPOUT6_W { w: self }
     }
     #[doc = "Bit 23 - Acknowledged data transfer on this OUT endpoint. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout7(&mut self) -> EPOUT7_W {
+    pub fn epout7(&mut self) -> EPOUT7_W<'_> {
         EPOUT7_W { w: self }
     }
 }

--- a/src/pac/usbd/epin/maxcnt.rs
+++ b/src/pac/usbd/epin/maxcnt.rs
@@ -34,7 +34,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:6 - Maximum number of bytes to transfer"]
     #[inline(always)]
-    pub fn maxcnt(&mut self) -> MAXCNT_W {
+    pub fn maxcnt(&mut self) -> MAXCNT_W<'_> {
         MAXCNT_W { w: self }
     }
 }

--- a/src/pac/usbd/epin/ptr.rs
+++ b/src/pac/usbd/epin/ptr.rs
@@ -34,7 +34,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:31 - Data pointer. Accepts any address in Data RAM."]
     #[inline(always)]
-    pub fn ptr(&mut self) -> PTR_W {
+    pub fn ptr(&mut self) -> PTR_W<'_> {
         PTR_W { w: self }
     }
 }

--- a/src/pac/usbd/epinen.rs
+++ b/src/pac/usbd/epinen.rs
@@ -735,47 +735,47 @@ impl R {
 impl W {
     #[doc = "Bit 0 - Enable IN endpoint 0"]
     #[inline(always)]
-    pub fn in0(&mut self) -> IN0_W {
+    pub fn in0(&mut self) -> IN0_W<'_> {
         IN0_W { w: self }
     }
     #[doc = "Bit 1 - Enable IN endpoint 1"]
     #[inline(always)]
-    pub fn in1(&mut self) -> IN1_W {
+    pub fn in1(&mut self) -> IN1_W<'_> {
         IN1_W { w: self }
     }
     #[doc = "Bit 2 - Enable IN endpoint 2"]
     #[inline(always)]
-    pub fn in2(&mut self) -> IN2_W {
+    pub fn in2(&mut self) -> IN2_W<'_> {
         IN2_W { w: self }
     }
     #[doc = "Bit 3 - Enable IN endpoint 3"]
     #[inline(always)]
-    pub fn in3(&mut self) -> IN3_W {
+    pub fn in3(&mut self) -> IN3_W<'_> {
         IN3_W { w: self }
     }
     #[doc = "Bit 4 - Enable IN endpoint 4"]
     #[inline(always)]
-    pub fn in4(&mut self) -> IN4_W {
+    pub fn in4(&mut self) -> IN4_W<'_> {
         IN4_W { w: self }
     }
     #[doc = "Bit 5 - Enable IN endpoint 5"]
     #[inline(always)]
-    pub fn in5(&mut self) -> IN5_W {
+    pub fn in5(&mut self) -> IN5_W<'_> {
         IN5_W { w: self }
     }
     #[doc = "Bit 6 - Enable IN endpoint 6"]
     #[inline(always)]
-    pub fn in6(&mut self) -> IN6_W {
+    pub fn in6(&mut self) -> IN6_W<'_> {
         IN6_W { w: self }
     }
     #[doc = "Bit 7 - Enable IN endpoint 7"]
     #[inline(always)]
-    pub fn in7(&mut self) -> IN7_W {
+    pub fn in7(&mut self) -> IN7_W<'_> {
         IN7_W { w: self }
     }
     #[doc = "Bit 8 - Enable ISO IN endpoint"]
     #[inline(always)]
-    pub fn isoin(&mut self) -> ISOIN_W {
+    pub fn isoin(&mut self) -> ISOIN_W<'_> {
         ISOIN_W { w: self }
     }
 }

--- a/src/pac/usbd/epout/maxcnt.rs
+++ b/src/pac/usbd/epout/maxcnt.rs
@@ -34,7 +34,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:6 - Maximum number of bytes to transfer"]
     #[inline(always)]
-    pub fn maxcnt(&mut self) -> MAXCNT_W {
+    pub fn maxcnt(&mut self) -> MAXCNT_W<'_> {
         MAXCNT_W { w: self }
     }
 }

--- a/src/pac/usbd/epout/ptr.rs
+++ b/src/pac/usbd/epout/ptr.rs
@@ -34,7 +34,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:31 - Data pointer. Accepts any address in Data RAM."]
     #[inline(always)]
-    pub fn ptr(&mut self) -> PTR_W {
+    pub fn ptr(&mut self) -> PTR_W<'_> {
         PTR_W { w: self }
     }
 }

--- a/src/pac/usbd/epouten.rs
+++ b/src/pac/usbd/epouten.rs
@@ -735,47 +735,47 @@ impl R {
 impl W {
     #[doc = "Bit 0 - Enable OUT endpoint 0"]
     #[inline(always)]
-    pub fn out0(&mut self) -> OUT0_W {
+    pub fn out0(&mut self) -> OUT0_W<'_> {
         OUT0_W { w: self }
     }
     #[doc = "Bit 1 - Enable OUT endpoint 1"]
     #[inline(always)]
-    pub fn out1(&mut self) -> OUT1_W {
+    pub fn out1(&mut self) -> OUT1_W<'_> {
         OUT1_W { w: self }
     }
     #[doc = "Bit 2 - Enable OUT endpoint 2"]
     #[inline(always)]
-    pub fn out2(&mut self) -> OUT2_W {
+    pub fn out2(&mut self) -> OUT2_W<'_> {
         OUT2_W { w: self }
     }
     #[doc = "Bit 3 - Enable OUT endpoint 3"]
     #[inline(always)]
-    pub fn out3(&mut self) -> OUT3_W {
+    pub fn out3(&mut self) -> OUT3_W<'_> {
         OUT3_W { w: self }
     }
     #[doc = "Bit 4 - Enable OUT endpoint 4"]
     #[inline(always)]
-    pub fn out4(&mut self) -> OUT4_W {
+    pub fn out4(&mut self) -> OUT4_W<'_> {
         OUT4_W { w: self }
     }
     #[doc = "Bit 5 - Enable OUT endpoint 5"]
     #[inline(always)]
-    pub fn out5(&mut self) -> OUT5_W {
+    pub fn out5(&mut self) -> OUT5_W<'_> {
         OUT5_W { w: self }
     }
     #[doc = "Bit 6 - Enable OUT endpoint 6"]
     #[inline(always)]
-    pub fn out6(&mut self) -> OUT6_W {
+    pub fn out6(&mut self) -> OUT6_W<'_> {
         OUT6_W { w: self }
     }
     #[doc = "Bit 7 - Enable OUT endpoint 7"]
     #[inline(always)]
-    pub fn out7(&mut self) -> OUT7_W {
+    pub fn out7(&mut self) -> OUT7_W<'_> {
         OUT7_W { w: self }
     }
     #[doc = "Bit 8 - Enable ISO OUT endpoint 8"]
     #[inline(always)]
-    pub fn isoout(&mut self) -> ISOOUT_W {
+    pub fn isoout(&mut self) -> ISOOUT_W<'_> {
         ISOOUT_W { w: self }
     }
 }

--- a/src/pac/usbd/epstall.rs
+++ b/src/pac/usbd/epstall.rs
@@ -129,17 +129,17 @@ impl<'a> STALL_W<'a> {
 impl W {
     #[doc = "Bits 0:2 - Select endpoint number"]
     #[inline(always)]
-    pub fn ep(&mut self) -> EP_W {
+    pub fn ep(&mut self) -> EP_W<'_> {
         EP_W { w: self }
     }
     #[doc = "Bit 7 - Selects IN or OUT endpoint"]
     #[inline(always)]
-    pub fn io(&mut self) -> IO_W {
+    pub fn io(&mut self) -> IO_W<'_> {
         IO_W { w: self }
     }
     #[doc = "Bit 8 - Stall selected endpoint"]
     #[inline(always)]
-    pub fn stall(&mut self) -> STALL_W {
+    pub fn stall(&mut self) -> STALL_W<'_> {
         STALL_W { w: self }
     }
 }

--- a/src/pac/usbd/epstatus.rs
+++ b/src/pac/usbd/epstatus.rs
@@ -1455,92 +1455,92 @@ impl R {
 impl W {
     #[doc = "Bit 0 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin0(&mut self) -> EPIN0_W {
+    pub fn epin0(&mut self) -> EPIN0_W<'_> {
         EPIN0_W { w: self }
     }
     #[doc = "Bit 1 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin1(&mut self) -> EPIN1_W {
+    pub fn epin1(&mut self) -> EPIN1_W<'_> {
         EPIN1_W { w: self }
     }
     #[doc = "Bit 2 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin2(&mut self) -> EPIN2_W {
+    pub fn epin2(&mut self) -> EPIN2_W<'_> {
         EPIN2_W { w: self }
     }
     #[doc = "Bit 3 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin3(&mut self) -> EPIN3_W {
+    pub fn epin3(&mut self) -> EPIN3_W<'_> {
         EPIN3_W { w: self }
     }
     #[doc = "Bit 4 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin4(&mut self) -> EPIN4_W {
+    pub fn epin4(&mut self) -> EPIN4_W<'_> {
         EPIN4_W { w: self }
     }
     #[doc = "Bit 5 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin5(&mut self) -> EPIN5_W {
+    pub fn epin5(&mut self) -> EPIN5_W<'_> {
         EPIN5_W { w: self }
     }
     #[doc = "Bit 6 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin6(&mut self) -> EPIN6_W {
+    pub fn epin6(&mut self) -> EPIN6_W<'_> {
         EPIN6_W { w: self }
     }
     #[doc = "Bit 7 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin7(&mut self) -> EPIN7_W {
+    pub fn epin7(&mut self) -> EPIN7_W<'_> {
         EPIN7_W { w: self }
     }
     #[doc = "Bit 8 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epin8(&mut self) -> EPIN8_W {
+    pub fn epin8(&mut self) -> EPIN8_W<'_> {
         EPIN8_W { w: self }
     }
     #[doc = "Bit 16 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout0(&mut self) -> EPOUT0_W {
+    pub fn epout0(&mut self) -> EPOUT0_W<'_> {
         EPOUT0_W { w: self }
     }
     #[doc = "Bit 17 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout1(&mut self) -> EPOUT1_W {
+    pub fn epout1(&mut self) -> EPOUT1_W<'_> {
         EPOUT1_W { w: self }
     }
     #[doc = "Bit 18 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout2(&mut self) -> EPOUT2_W {
+    pub fn epout2(&mut self) -> EPOUT2_W<'_> {
         EPOUT2_W { w: self }
     }
     #[doc = "Bit 19 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout3(&mut self) -> EPOUT3_W {
+    pub fn epout3(&mut self) -> EPOUT3_W<'_> {
         EPOUT3_W { w: self }
     }
     #[doc = "Bit 20 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout4(&mut self) -> EPOUT4_W {
+    pub fn epout4(&mut self) -> EPOUT4_W<'_> {
         EPOUT4_W { w: self }
     }
     #[doc = "Bit 21 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout5(&mut self) -> EPOUT5_W {
+    pub fn epout5(&mut self) -> EPOUT5_W<'_> {
         EPOUT5_W { w: self }
     }
     #[doc = "Bit 22 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout6(&mut self) -> EPOUT6_W {
+    pub fn epout6(&mut self) -> EPOUT6_W<'_> {
         EPOUT6_W { w: self }
     }
     #[doc = "Bit 23 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout7(&mut self) -> EPOUT7_W {
+    pub fn epout7(&mut self) -> EPOUT7_W<'_> {
         EPOUT7_W { w: self }
     }
     #[doc = "Bit 24 - Captured state of endpoint's EasyDMA registers. Write '1' to clear."]
     #[inline(always)]
-    pub fn epout8(&mut self) -> EPOUT8_W {
+    pub fn epout8(&mut self) -> EPOUT8_W<'_> {
         EPOUT8_W { w: self }
     }
 }

--- a/src/pac/usbd/eventcause.rs
+++ b/src/pac/usbd/eventcause.rs
@@ -415,27 +415,27 @@ impl R {
 impl W {
     #[doc = "Bit 0 - CRC error was detected on isochronous OUT endpoint 8. Write '1' to clear."]
     #[inline(always)]
-    pub fn isooutcrc(&mut self) -> ISOOUTCRC_W {
+    pub fn isooutcrc(&mut self) -> ISOOUTCRC_W<'_> {
         ISOOUTCRC_W { w: self }
     }
     #[doc = "Bit 8 - Signals that USB lines have been idle long enough for the device to enter suspend. Write '1' to clear."]
     #[inline(always)]
-    pub fn suspend(&mut self) -> SUSPEND_W {
+    pub fn suspend(&mut self) -> SUSPEND_W<'_> {
         SUSPEND_W { w: self }
     }
     #[doc = "Bit 9 - Signals that a RESUME condition (K state or activity restart) has been detected on USB lines. Write '1' to clear."]
     #[inline(always)]
-    pub fn resume(&mut self) -> RESUME_W {
+    pub fn resume(&mut self) -> RESUME_W<'_> {
         RESUME_W { w: self }
     }
     #[doc = "Bit 10 - USB MAC has been woken up and operational. Write '1' to clear."]
     #[inline(always)]
-    pub fn usbwuallowed(&mut self) -> USBWUALLOWED_W {
+    pub fn usbwuallowed(&mut self) -> USBWUALLOWED_W<'_> {
         USBWUALLOWED_W { w: self }
     }
     #[doc = "Bit 11 - USB device is ready for normal operation. Write '1' to clear."]
     #[inline(always)]
-    pub fn ready(&mut self) -> READY_W {
+    pub fn ready(&mut self) -> READY_W<'_> {
         READY_W { w: self }
     }
 }

--- a/src/pac/usbd/events_endepin.rs
+++ b/src/pac/usbd/events_endepin.rs
@@ -45,7 +45,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_endepin(&mut self) -> EVENTS_ENDEPIN_W {
+    pub fn events_endepin(&mut self) -> EVENTS_ENDEPIN_W<'_> {
         EVENTS_ENDEPIN_W { w: self }
     }
 }

--- a/src/pac/usbd/events_endepout.rs
+++ b/src/pac/usbd/events_endepout.rs
@@ -45,7 +45,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_endepout(&mut self) -> EVENTS_ENDEPOUT_W {
+    pub fn events_endepout(&mut self) -> EVENTS_ENDEPOUT_W<'_> {
         EVENTS_ENDEPOUT_W { w: self }
     }
 }

--- a/src/pac/usbd/events_endisoin.rs
+++ b/src/pac/usbd/events_endisoin.rs
@@ -44,7 +44,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_endisoin(&mut self) -> EVENTS_ENDISOIN_W {
+    pub fn events_endisoin(&mut self) -> EVENTS_ENDISOIN_W<'_> {
         EVENTS_ENDISOIN_W { w: self }
     }
 }

--- a/src/pac/usbd/events_endisoout.rs
+++ b/src/pac/usbd/events_endisoout.rs
@@ -44,7 +44,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_endisoout(&mut self) -> EVENTS_ENDISOOUT_W {
+    pub fn events_endisoout(&mut self) -> EVENTS_ENDISOOUT_W<'_> {
         EVENTS_ENDISOOUT_W { w: self }
     }
 }

--- a/src/pac/usbd/events_ep0datadone.rs
+++ b/src/pac/usbd/events_ep0datadone.rs
@@ -44,7 +44,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_ep0datadone(&mut self) -> EVENTS_EP0DATADONE_W {
+    pub fn events_ep0datadone(&mut self) -> EVENTS_EP0DATADONE_W<'_> {
         EVENTS_EP0DATADONE_W { w: self }
     }
 }

--- a/src/pac/usbd/events_ep0setup.rs
+++ b/src/pac/usbd/events_ep0setup.rs
@@ -44,7 +44,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_ep0setup(&mut self) -> EVENTS_EP0SETUP_W {
+    pub fn events_ep0setup(&mut self) -> EVENTS_EP0SETUP_W<'_> {
         EVENTS_EP0SETUP_W { w: self }
     }
 }

--- a/src/pac/usbd/events_epdata.rs
+++ b/src/pac/usbd/events_epdata.rs
@@ -44,7 +44,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_epdata(&mut self) -> EVENTS_EPDATA_W {
+    pub fn events_epdata(&mut self) -> EVENTS_EPDATA_W<'_> {
         EVENTS_EPDATA_W { w: self }
     }
 }

--- a/src/pac/usbd/events_sof.rs
+++ b/src/pac/usbd/events_sof.rs
@@ -44,7 +44,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_sof(&mut self) -> EVENTS_SOF_W {
+    pub fn events_sof(&mut self) -> EVENTS_SOF_W<'_> {
         EVENTS_SOF_W { w: self }
     }
 }

--- a/src/pac/usbd/events_started.rs
+++ b/src/pac/usbd/events_started.rs
@@ -44,7 +44,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_started(&mut self) -> EVENTS_STARTED_W {
+    pub fn events_started(&mut self) -> EVENTS_STARTED_W<'_> {
         EVENTS_STARTED_W { w: self }
     }
 }

--- a/src/pac/usbd/events_usbevent.rs
+++ b/src/pac/usbd/events_usbevent.rs
@@ -44,7 +44,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_usbevent(&mut self) -> EVENTS_USBEVENT_W {
+    pub fn events_usbevent(&mut self) -> EVENTS_USBEVENT_W<'_> {
         EVENTS_USBEVENT_W { w: self }
     }
 }

--- a/src/pac/usbd/events_usbreset.rs
+++ b/src/pac/usbd/events_usbreset.rs
@@ -44,7 +44,7 @@ impl R {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn events_usbreset(&mut self) -> EVENTS_USBRESET_W {
+    pub fn events_usbreset(&mut self) -> EVENTS_USBRESET_W<'_> {
         EVENTS_USBRESET_W { w: self }
     }
 }

--- a/src/pac/usbd/inten.rs
+++ b/src/pac/usbd/inten.rs
@@ -2047,143 +2047,143 @@ event"]
 impl W {
     #[doc = "Bit 0 - Enable or disable interrupt for USBRESET event"]
     #[inline(always)]
-    pub fn usbreset(&mut self) -> USBRESET_W {
+    pub fn usbreset(&mut self) -> USBRESET_W<'_> {
         USBRESET_W { w: self }
     }
     #[doc = "Bit 1 - Enable or disable interrupt for STARTED event"]
     #[inline(always)]
-    pub fn started(&mut self) -> STARTED_W {
+    pub fn started(&mut self) -> STARTED_W<'_> {
         STARTED_W { w: self }
     }
     #[doc = "Bit 2 - Enable or disable interrupt for ENDEPIN\\[0\\]
 event"]
     #[inline(always)]
-    pub fn endepin0(&mut self) -> ENDEPIN0_W {
+    pub fn endepin0(&mut self) -> ENDEPIN0_W<'_> {
         ENDEPIN0_W { w: self }
     }
     #[doc = "Bit 3 - Enable or disable interrupt for ENDEPIN\\[1\\]
 event"]
     #[inline(always)]
-    pub fn endepin1(&mut self) -> ENDEPIN1_W {
+    pub fn endepin1(&mut self) -> ENDEPIN1_W<'_> {
         ENDEPIN1_W { w: self }
     }
     #[doc = "Bit 4 - Enable or disable interrupt for ENDEPIN\\[2\\]
 event"]
     #[inline(always)]
-    pub fn endepin2(&mut self) -> ENDEPIN2_W {
+    pub fn endepin2(&mut self) -> ENDEPIN2_W<'_> {
         ENDEPIN2_W { w: self }
     }
     #[doc = "Bit 5 - Enable or disable interrupt for ENDEPIN\\[3\\]
 event"]
     #[inline(always)]
-    pub fn endepin3(&mut self) -> ENDEPIN3_W {
+    pub fn endepin3(&mut self) -> ENDEPIN3_W<'_> {
         ENDEPIN3_W { w: self }
     }
     #[doc = "Bit 6 - Enable or disable interrupt for ENDEPIN\\[4\\]
 event"]
     #[inline(always)]
-    pub fn endepin4(&mut self) -> ENDEPIN4_W {
+    pub fn endepin4(&mut self) -> ENDEPIN4_W<'_> {
         ENDEPIN4_W { w: self }
     }
     #[doc = "Bit 7 - Enable or disable interrupt for ENDEPIN\\[5\\]
 event"]
     #[inline(always)]
-    pub fn endepin5(&mut self) -> ENDEPIN5_W {
+    pub fn endepin5(&mut self) -> ENDEPIN5_W<'_> {
         ENDEPIN5_W { w: self }
     }
     #[doc = "Bit 8 - Enable or disable interrupt for ENDEPIN\\[6\\]
 event"]
     #[inline(always)]
-    pub fn endepin6(&mut self) -> ENDEPIN6_W {
+    pub fn endepin6(&mut self) -> ENDEPIN6_W<'_> {
         ENDEPIN6_W { w: self }
     }
     #[doc = "Bit 9 - Enable or disable interrupt for ENDEPIN\\[7\\]
 event"]
     #[inline(always)]
-    pub fn endepin7(&mut self) -> ENDEPIN7_W {
+    pub fn endepin7(&mut self) -> ENDEPIN7_W<'_> {
         ENDEPIN7_W { w: self }
     }
     #[doc = "Bit 10 - Enable or disable interrupt for EP0DATADONE event"]
     #[inline(always)]
-    pub fn ep0datadone(&mut self) -> EP0DATADONE_W {
+    pub fn ep0datadone(&mut self) -> EP0DATADONE_W<'_> {
         EP0DATADONE_W { w: self }
     }
     #[doc = "Bit 11 - Enable or disable interrupt for ENDISOIN event"]
     #[inline(always)]
-    pub fn endisoin(&mut self) -> ENDISOIN_W {
+    pub fn endisoin(&mut self) -> ENDISOIN_W<'_> {
         ENDISOIN_W { w: self }
     }
     #[doc = "Bit 12 - Enable or disable interrupt for ENDEPOUT\\[0\\]
 event"]
     #[inline(always)]
-    pub fn endepout0(&mut self) -> ENDEPOUT0_W {
+    pub fn endepout0(&mut self) -> ENDEPOUT0_W<'_> {
         ENDEPOUT0_W { w: self }
     }
     #[doc = "Bit 13 - Enable or disable interrupt for ENDEPOUT\\[1\\]
 event"]
     #[inline(always)]
-    pub fn endepout1(&mut self) -> ENDEPOUT1_W {
+    pub fn endepout1(&mut self) -> ENDEPOUT1_W<'_> {
         ENDEPOUT1_W { w: self }
     }
     #[doc = "Bit 14 - Enable or disable interrupt for ENDEPOUT\\[2\\]
 event"]
     #[inline(always)]
-    pub fn endepout2(&mut self) -> ENDEPOUT2_W {
+    pub fn endepout2(&mut self) -> ENDEPOUT2_W<'_> {
         ENDEPOUT2_W { w: self }
     }
     #[doc = "Bit 15 - Enable or disable interrupt for ENDEPOUT\\[3\\]
 event"]
     #[inline(always)]
-    pub fn endepout3(&mut self) -> ENDEPOUT3_W {
+    pub fn endepout3(&mut self) -> ENDEPOUT3_W<'_> {
         ENDEPOUT3_W { w: self }
     }
     #[doc = "Bit 16 - Enable or disable interrupt for ENDEPOUT\\[4\\]
 event"]
     #[inline(always)]
-    pub fn endepout4(&mut self) -> ENDEPOUT4_W {
+    pub fn endepout4(&mut self) -> ENDEPOUT4_W<'_> {
         ENDEPOUT4_W { w: self }
     }
     #[doc = "Bit 17 - Enable or disable interrupt for ENDEPOUT\\[5\\]
 event"]
     #[inline(always)]
-    pub fn endepout5(&mut self) -> ENDEPOUT5_W {
+    pub fn endepout5(&mut self) -> ENDEPOUT5_W<'_> {
         ENDEPOUT5_W { w: self }
     }
     #[doc = "Bit 18 - Enable or disable interrupt for ENDEPOUT\\[6\\]
 event"]
     #[inline(always)]
-    pub fn endepout6(&mut self) -> ENDEPOUT6_W {
+    pub fn endepout6(&mut self) -> ENDEPOUT6_W<'_> {
         ENDEPOUT6_W { w: self }
     }
     #[doc = "Bit 19 - Enable or disable interrupt for ENDEPOUT\\[7\\]
 event"]
     #[inline(always)]
-    pub fn endepout7(&mut self) -> ENDEPOUT7_W {
+    pub fn endepout7(&mut self) -> ENDEPOUT7_W<'_> {
         ENDEPOUT7_W { w: self }
     }
     #[doc = "Bit 20 - Enable or disable interrupt for ENDISOOUT event"]
     #[inline(always)]
-    pub fn endisoout(&mut self) -> ENDISOOUT_W {
+    pub fn endisoout(&mut self) -> ENDISOOUT_W<'_> {
         ENDISOOUT_W { w: self }
     }
     #[doc = "Bit 21 - Enable or disable interrupt for SOF event"]
     #[inline(always)]
-    pub fn sof(&mut self) -> SOF_W {
+    pub fn sof(&mut self) -> SOF_W<'_> {
         SOF_W { w: self }
     }
     #[doc = "Bit 22 - Enable or disable interrupt for USBEVENT event"]
     #[inline(always)]
-    pub fn usbevent(&mut self) -> USBEVENT_W {
+    pub fn usbevent(&mut self) -> USBEVENT_W<'_> {
         USBEVENT_W { w: self }
     }
     #[doc = "Bit 23 - Enable or disable interrupt for EP0SETUP event"]
     #[inline(always)]
-    pub fn ep0setup(&mut self) -> EP0SETUP_W {
+    pub fn ep0setup(&mut self) -> EP0SETUP_W<'_> {
         EP0SETUP_W { w: self }
     }
     #[doc = "Bit 24 - Enable or disable interrupt for EPDATA event"]
     #[inline(always)]
-    pub fn epdata(&mut self) -> EPDATA_W {
+    pub fn epdata(&mut self) -> EPDATA_W<'_> {
         EPDATA_W { w: self }
     }
 }

--- a/src/pac/usbd/intenclr.rs
+++ b/src/pac/usbd/intenclr.rs
@@ -2238,143 +2238,143 @@ event"]
 impl W {
     #[doc = "Bit 0 - Write '1' to disable interrupt for USBRESET event"]
     #[inline(always)]
-    pub fn usbreset(&mut self) -> USBRESET_W {
+    pub fn usbreset(&mut self) -> USBRESET_W<'_> {
         USBRESET_W { w: self }
     }
     #[doc = "Bit 1 - Write '1' to disable interrupt for STARTED event"]
     #[inline(always)]
-    pub fn started(&mut self) -> STARTED_W {
+    pub fn started(&mut self) -> STARTED_W<'_> {
         STARTED_W { w: self }
     }
     #[doc = "Bit 2 - Write '1' to disable interrupt for ENDEPIN\\[0\\]
 event"]
     #[inline(always)]
-    pub fn endepin0(&mut self) -> ENDEPIN0_W {
+    pub fn endepin0(&mut self) -> ENDEPIN0_W<'_> {
         ENDEPIN0_W { w: self }
     }
     #[doc = "Bit 3 - Write '1' to disable interrupt for ENDEPIN\\[1\\]
 event"]
     #[inline(always)]
-    pub fn endepin1(&mut self) -> ENDEPIN1_W {
+    pub fn endepin1(&mut self) -> ENDEPIN1_W<'_> {
         ENDEPIN1_W { w: self }
     }
     #[doc = "Bit 4 - Write '1' to disable interrupt for ENDEPIN\\[2\\]
 event"]
     #[inline(always)]
-    pub fn endepin2(&mut self) -> ENDEPIN2_W {
+    pub fn endepin2(&mut self) -> ENDEPIN2_W<'_> {
         ENDEPIN2_W { w: self }
     }
     #[doc = "Bit 5 - Write '1' to disable interrupt for ENDEPIN\\[3\\]
 event"]
     #[inline(always)]
-    pub fn endepin3(&mut self) -> ENDEPIN3_W {
+    pub fn endepin3(&mut self) -> ENDEPIN3_W<'_> {
         ENDEPIN3_W { w: self }
     }
     #[doc = "Bit 6 - Write '1' to disable interrupt for ENDEPIN\\[4\\]
 event"]
     #[inline(always)]
-    pub fn endepin4(&mut self) -> ENDEPIN4_W {
+    pub fn endepin4(&mut self) -> ENDEPIN4_W<'_> {
         ENDEPIN4_W { w: self }
     }
     #[doc = "Bit 7 - Write '1' to disable interrupt for ENDEPIN\\[5\\]
 event"]
     #[inline(always)]
-    pub fn endepin5(&mut self) -> ENDEPIN5_W {
+    pub fn endepin5(&mut self) -> ENDEPIN5_W<'_> {
         ENDEPIN5_W { w: self }
     }
     #[doc = "Bit 8 - Write '1' to disable interrupt for ENDEPIN\\[6\\]
 event"]
     #[inline(always)]
-    pub fn endepin6(&mut self) -> ENDEPIN6_W {
+    pub fn endepin6(&mut self) -> ENDEPIN6_W<'_> {
         ENDEPIN6_W { w: self }
     }
     #[doc = "Bit 9 - Write '1' to disable interrupt for ENDEPIN\\[7\\]
 event"]
     #[inline(always)]
-    pub fn endepin7(&mut self) -> ENDEPIN7_W {
+    pub fn endepin7(&mut self) -> ENDEPIN7_W<'_> {
         ENDEPIN7_W { w: self }
     }
     #[doc = "Bit 10 - Write '1' to disable interrupt for EP0DATADONE event"]
     #[inline(always)]
-    pub fn ep0datadone(&mut self) -> EP0DATADONE_W {
+    pub fn ep0datadone(&mut self) -> EP0DATADONE_W<'_> {
         EP0DATADONE_W { w: self }
     }
     #[doc = "Bit 11 - Write '1' to disable interrupt for ENDISOIN event"]
     #[inline(always)]
-    pub fn endisoin(&mut self) -> ENDISOIN_W {
+    pub fn endisoin(&mut self) -> ENDISOIN_W<'_> {
         ENDISOIN_W { w: self }
     }
     #[doc = "Bit 12 - Write '1' to disable interrupt for ENDEPOUT\\[0\\]
 event"]
     #[inline(always)]
-    pub fn endepout0(&mut self) -> ENDEPOUT0_W {
+    pub fn endepout0(&mut self) -> ENDEPOUT0_W<'_> {
         ENDEPOUT0_W { w: self }
     }
     #[doc = "Bit 13 - Write '1' to disable interrupt for ENDEPOUT\\[1\\]
 event"]
     #[inline(always)]
-    pub fn endepout1(&mut self) -> ENDEPOUT1_W {
+    pub fn endepout1(&mut self) -> ENDEPOUT1_W<'_> {
         ENDEPOUT1_W { w: self }
     }
     #[doc = "Bit 14 - Write '1' to disable interrupt for ENDEPOUT\\[2\\]
 event"]
     #[inline(always)]
-    pub fn endepout2(&mut self) -> ENDEPOUT2_W {
+    pub fn endepout2(&mut self) -> ENDEPOUT2_W<'_> {
         ENDEPOUT2_W { w: self }
     }
     #[doc = "Bit 15 - Write '1' to disable interrupt for ENDEPOUT\\[3\\]
 event"]
     #[inline(always)]
-    pub fn endepout3(&mut self) -> ENDEPOUT3_W {
+    pub fn endepout3(&mut self) -> ENDEPOUT3_W<'_> {
         ENDEPOUT3_W { w: self }
     }
     #[doc = "Bit 16 - Write '1' to disable interrupt for ENDEPOUT\\[4\\]
 event"]
     #[inline(always)]
-    pub fn endepout4(&mut self) -> ENDEPOUT4_W {
+    pub fn endepout4(&mut self) -> ENDEPOUT4_W<'_> {
         ENDEPOUT4_W { w: self }
     }
     #[doc = "Bit 17 - Write '1' to disable interrupt for ENDEPOUT\\[5\\]
 event"]
     #[inline(always)]
-    pub fn endepout5(&mut self) -> ENDEPOUT5_W {
+    pub fn endepout5(&mut self) -> ENDEPOUT5_W<'_> {
         ENDEPOUT5_W { w: self }
     }
     #[doc = "Bit 18 - Write '1' to disable interrupt for ENDEPOUT\\[6\\]
 event"]
     #[inline(always)]
-    pub fn endepout6(&mut self) -> ENDEPOUT6_W {
+    pub fn endepout6(&mut self) -> ENDEPOUT6_W<'_> {
         ENDEPOUT6_W { w: self }
     }
     #[doc = "Bit 19 - Write '1' to disable interrupt for ENDEPOUT\\[7\\]
 event"]
     #[inline(always)]
-    pub fn endepout7(&mut self) -> ENDEPOUT7_W {
+    pub fn endepout7(&mut self) -> ENDEPOUT7_W<'_> {
         ENDEPOUT7_W { w: self }
     }
     #[doc = "Bit 20 - Write '1' to disable interrupt for ENDISOOUT event"]
     #[inline(always)]
-    pub fn endisoout(&mut self) -> ENDISOOUT_W {
+    pub fn endisoout(&mut self) -> ENDISOOUT_W<'_> {
         ENDISOOUT_W { w: self }
     }
     #[doc = "Bit 21 - Write '1' to disable interrupt for SOF event"]
     #[inline(always)]
-    pub fn sof(&mut self) -> SOF_W {
+    pub fn sof(&mut self) -> SOF_W<'_> {
         SOF_W { w: self }
     }
     #[doc = "Bit 22 - Write '1' to disable interrupt for USBEVENT event"]
     #[inline(always)]
-    pub fn usbevent(&mut self) -> USBEVENT_W {
+    pub fn usbevent(&mut self) -> USBEVENT_W<'_> {
         USBEVENT_W { w: self }
     }
     #[doc = "Bit 23 - Write '1' to disable interrupt for EP0SETUP event"]
     #[inline(always)]
-    pub fn ep0setup(&mut self) -> EP0SETUP_W {
+    pub fn ep0setup(&mut self) -> EP0SETUP_W<'_> {
         EP0SETUP_W { w: self }
     }
     #[doc = "Bit 24 - Write '1' to disable interrupt for EPDATA event"]
     #[inline(always)]
-    pub fn epdata(&mut self) -> EPDATA_W {
+    pub fn epdata(&mut self) -> EPDATA_W<'_> {
         EPDATA_W { w: self }
     }
 }

--- a/src/pac/usbd/intenset.rs
+++ b/src/pac/usbd/intenset.rs
@@ -2238,143 +2238,143 @@ event"]
 impl W {
     #[doc = "Bit 0 - Write '1' to enable interrupt for USBRESET event"]
     #[inline(always)]
-    pub fn usbreset(&mut self) -> USBRESET_W {
+    pub fn usbreset(&mut self) -> USBRESET_W<'_> {
         USBRESET_W { w: self }
     }
     #[doc = "Bit 1 - Write '1' to enable interrupt for STARTED event"]
     #[inline(always)]
-    pub fn started(&mut self) -> STARTED_W {
+    pub fn started(&mut self) -> STARTED_W<'_> {
         STARTED_W { w: self }
     }
     #[doc = "Bit 2 - Write '1' to enable interrupt for ENDEPIN\\[0\\]
 event"]
     #[inline(always)]
-    pub fn endepin0(&mut self) -> ENDEPIN0_W {
+    pub fn endepin0(&mut self) -> ENDEPIN0_W<'_> {
         ENDEPIN0_W { w: self }
     }
     #[doc = "Bit 3 - Write '1' to enable interrupt for ENDEPIN\\[1\\]
 event"]
     #[inline(always)]
-    pub fn endepin1(&mut self) -> ENDEPIN1_W {
+    pub fn endepin1(&mut self) -> ENDEPIN1_W<'_> {
         ENDEPIN1_W { w: self }
     }
     #[doc = "Bit 4 - Write '1' to enable interrupt for ENDEPIN\\[2\\]
 event"]
     #[inline(always)]
-    pub fn endepin2(&mut self) -> ENDEPIN2_W {
+    pub fn endepin2(&mut self) -> ENDEPIN2_W<'_> {
         ENDEPIN2_W { w: self }
     }
     #[doc = "Bit 5 - Write '1' to enable interrupt for ENDEPIN\\[3\\]
 event"]
     #[inline(always)]
-    pub fn endepin3(&mut self) -> ENDEPIN3_W {
+    pub fn endepin3(&mut self) -> ENDEPIN3_W<'_> {
         ENDEPIN3_W { w: self }
     }
     #[doc = "Bit 6 - Write '1' to enable interrupt for ENDEPIN\\[4\\]
 event"]
     #[inline(always)]
-    pub fn endepin4(&mut self) -> ENDEPIN4_W {
+    pub fn endepin4(&mut self) -> ENDEPIN4_W<'_> {
         ENDEPIN4_W { w: self }
     }
     #[doc = "Bit 7 - Write '1' to enable interrupt for ENDEPIN\\[5\\]
 event"]
     #[inline(always)]
-    pub fn endepin5(&mut self) -> ENDEPIN5_W {
+    pub fn endepin5(&mut self) -> ENDEPIN5_W<'_> {
         ENDEPIN5_W { w: self }
     }
     #[doc = "Bit 8 - Write '1' to enable interrupt for ENDEPIN\\[6\\]
 event"]
     #[inline(always)]
-    pub fn endepin6(&mut self) -> ENDEPIN6_W {
+    pub fn endepin6(&mut self) -> ENDEPIN6_W<'_> {
         ENDEPIN6_W { w: self }
     }
     #[doc = "Bit 9 - Write '1' to enable interrupt for ENDEPIN\\[7\\]
 event"]
     #[inline(always)]
-    pub fn endepin7(&mut self) -> ENDEPIN7_W {
+    pub fn endepin7(&mut self) -> ENDEPIN7_W<'_> {
         ENDEPIN7_W { w: self }
     }
     #[doc = "Bit 10 - Write '1' to enable interrupt for EP0DATADONE event"]
     #[inline(always)]
-    pub fn ep0datadone(&mut self) -> EP0DATADONE_W {
+    pub fn ep0datadone(&mut self) -> EP0DATADONE_W<'_> {
         EP0DATADONE_W { w: self }
     }
     #[doc = "Bit 11 - Write '1' to enable interrupt for ENDISOIN event"]
     #[inline(always)]
-    pub fn endisoin(&mut self) -> ENDISOIN_W {
+    pub fn endisoin(&mut self) -> ENDISOIN_W<'_> {
         ENDISOIN_W { w: self }
     }
     #[doc = "Bit 12 - Write '1' to enable interrupt for ENDEPOUT\\[0\\]
 event"]
     #[inline(always)]
-    pub fn endepout0(&mut self) -> ENDEPOUT0_W {
+    pub fn endepout0(&mut self) -> ENDEPOUT0_W<'_> {
         ENDEPOUT0_W { w: self }
     }
     #[doc = "Bit 13 - Write '1' to enable interrupt for ENDEPOUT\\[1\\]
 event"]
     #[inline(always)]
-    pub fn endepout1(&mut self) -> ENDEPOUT1_W {
+    pub fn endepout1(&mut self) -> ENDEPOUT1_W<'_> {
         ENDEPOUT1_W { w: self }
     }
     #[doc = "Bit 14 - Write '1' to enable interrupt for ENDEPOUT\\[2\\]
 event"]
     #[inline(always)]
-    pub fn endepout2(&mut self) -> ENDEPOUT2_W {
+    pub fn endepout2(&mut self) -> ENDEPOUT2_W<'_> {
         ENDEPOUT2_W { w: self }
     }
     #[doc = "Bit 15 - Write '1' to enable interrupt for ENDEPOUT\\[3\\]
 event"]
     #[inline(always)]
-    pub fn endepout3(&mut self) -> ENDEPOUT3_W {
+    pub fn endepout3(&mut self) -> ENDEPOUT3_W<'_> {
         ENDEPOUT3_W { w: self }
     }
     #[doc = "Bit 16 - Write '1' to enable interrupt for ENDEPOUT\\[4\\]
 event"]
     #[inline(always)]
-    pub fn endepout4(&mut self) -> ENDEPOUT4_W {
+    pub fn endepout4(&mut self) -> ENDEPOUT4_W<'_> {
         ENDEPOUT4_W { w: self }
     }
     #[doc = "Bit 17 - Write '1' to enable interrupt for ENDEPOUT\\[5\\]
 event"]
     #[inline(always)]
-    pub fn endepout5(&mut self) -> ENDEPOUT5_W {
+    pub fn endepout5(&mut self) -> ENDEPOUT5_W<'_> {
         ENDEPOUT5_W { w: self }
     }
     #[doc = "Bit 18 - Write '1' to enable interrupt for ENDEPOUT\\[6\\]
 event"]
     #[inline(always)]
-    pub fn endepout6(&mut self) -> ENDEPOUT6_W {
+    pub fn endepout6(&mut self) -> ENDEPOUT6_W<'_> {
         ENDEPOUT6_W { w: self }
     }
     #[doc = "Bit 19 - Write '1' to enable interrupt for ENDEPOUT\\[7\\]
 event"]
     #[inline(always)]
-    pub fn endepout7(&mut self) -> ENDEPOUT7_W {
+    pub fn endepout7(&mut self) -> ENDEPOUT7_W<'_> {
         ENDEPOUT7_W { w: self }
     }
     #[doc = "Bit 20 - Write '1' to enable interrupt for ENDISOOUT event"]
     #[inline(always)]
-    pub fn endisoout(&mut self) -> ENDISOOUT_W {
+    pub fn endisoout(&mut self) -> ENDISOOUT_W<'_> {
         ENDISOOUT_W { w: self }
     }
     #[doc = "Bit 21 - Write '1' to enable interrupt for SOF event"]
     #[inline(always)]
-    pub fn sof(&mut self) -> SOF_W {
+    pub fn sof(&mut self) -> SOF_W<'_> {
         SOF_W { w: self }
     }
     #[doc = "Bit 22 - Write '1' to enable interrupt for USBEVENT event"]
     #[inline(always)]
-    pub fn usbevent(&mut self) -> USBEVENT_W {
+    pub fn usbevent(&mut self) -> USBEVENT_W<'_> {
         USBEVENT_W { w: self }
     }
     #[doc = "Bit 23 - Write '1' to enable interrupt for EP0SETUP event"]
     #[inline(always)]
-    pub fn ep0setup(&mut self) -> EP0SETUP_W {
+    pub fn ep0setup(&mut self) -> EP0SETUP_W<'_> {
         EP0SETUP_W { w: self }
     }
     #[doc = "Bit 24 - Write '1' to enable interrupt for EPDATA event"]
     #[inline(always)]
-    pub fn epdata(&mut self) -> EPDATA_W {
+    pub fn epdata(&mut self) -> EPDATA_W<'_> {
         EPDATA_W { w: self }
     }
 }

--- a/src/pac/usbd/isoin/maxcnt.rs
+++ b/src/pac/usbd/isoin/maxcnt.rs
@@ -34,7 +34,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:9 - Maximum number of bytes to transfer"]
     #[inline(always)]
-    pub fn maxcnt(&mut self) -> MAXCNT_W {
+    pub fn maxcnt(&mut self) -> MAXCNT_W<'_> {
         MAXCNT_W { w: self }
     }
 }

--- a/src/pac/usbd/isoin/ptr.rs
+++ b/src/pac/usbd/isoin/ptr.rs
@@ -34,7 +34,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:31 - Data pointer. Accepts any address in Data RAM."]
     #[inline(always)]
-    pub fn ptr(&mut self) -> PTR_W {
+    pub fn ptr(&mut self) -> PTR_W<'_> {
         PTR_W { w: self }
     }
 }

--- a/src/pac/usbd/isoinconfig.rs
+++ b/src/pac/usbd/isoinconfig.rs
@@ -95,7 +95,7 @@ impl R {
 impl W {
     #[doc = "Bit 0 - Controls the response of the ISO IN endpoint to an IN token when no data is ready to be sent"]
     #[inline(always)]
-    pub fn response(&mut self) -> RESPONSE_W {
+    pub fn response(&mut self) -> RESPONSE_W<'_> {
         RESPONSE_W { w: self }
     }
 }

--- a/src/pac/usbd/isoout/maxcnt.rs
+++ b/src/pac/usbd/isoout/maxcnt.rs
@@ -34,7 +34,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:9 - Maximum number of bytes to transfer"]
     #[inline(always)]
-    pub fn maxcnt(&mut self) -> MAXCNT_W {
+    pub fn maxcnt(&mut self) -> MAXCNT_W<'_> {
         MAXCNT_W { w: self }
     }
 }

--- a/src/pac/usbd/isoout/ptr.rs
+++ b/src/pac/usbd/isoout/ptr.rs
@@ -34,7 +34,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:31 - Data pointer. Accepts any address in Data RAM."]
     #[inline(always)]
-    pub fn ptr(&mut self) -> PTR_W {
+    pub fn ptr(&mut self) -> PTR_W<'_> {
         PTR_W { w: self }
     }
 }

--- a/src/pac/usbd/isosplit.rs
+++ b/src/pac/usbd/isosplit.rs
@@ -86,7 +86,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:15 - Controls the split of ISO buffers"]
     #[inline(always)]
-    pub fn split(&mut self) -> SPLIT_W {
+    pub fn split(&mut self) -> SPLIT_W<'_> {
         SPLIT_W { w: self }
     }
 }

--- a/src/pac/usbd/lowpower.rs
+++ b/src/pac/usbd/lowpower.rs
@@ -95,7 +95,7 @@ impl R {
 impl W {
     #[doc = "Bit 0 - Controls USBD peripheral low-power mode during USB suspend"]
     #[inline(always)]
-    pub fn lowpower(&mut self) -> LOWPOWER_W {
+    pub fn lowpower(&mut self) -> LOWPOWER_W<'_> {
         LOWPOWER_W { w: self }
     }
 }

--- a/src/pac/usbd/shorts.rs
+++ b/src/pac/usbd/shorts.rs
@@ -424,30 +424,30 @@ impl W {
     #[doc = "Bit 0 - Shortcut between EP0DATADONE event and STARTEPIN\\[0\\]
 task"]
     #[inline(always)]
-    pub fn ep0datadone_startepin0(&mut self) -> EP0DATADONE_STARTEPIN0_W {
+    pub fn ep0datadone_startepin0(&mut self) -> EP0DATADONE_STARTEPIN0_W<'_> {
         EP0DATADONE_STARTEPIN0_W { w: self }
     }
     #[doc = "Bit 1 - Shortcut between EP0DATADONE event and STARTEPOUT\\[0\\]
 task"]
     #[inline(always)]
-    pub fn ep0datadone_startepout0(&mut self) -> EP0DATADONE_STARTEPOUT0_W {
+    pub fn ep0datadone_startepout0(&mut self) -> EP0DATADONE_STARTEPOUT0_W<'_> {
         EP0DATADONE_STARTEPOUT0_W { w: self }
     }
     #[doc = "Bit 2 - Shortcut between EP0DATADONE event and EP0STATUS task"]
     #[inline(always)]
-    pub fn ep0datadone_ep0status(&mut self) -> EP0DATADONE_EP0STATUS_W {
+    pub fn ep0datadone_ep0status(&mut self) -> EP0DATADONE_EP0STATUS_W<'_> {
         EP0DATADONE_EP0STATUS_W { w: self }
     }
     #[doc = "Bit 3 - Shortcut between ENDEPOUT\\[0\\]
 event and EP0STATUS task"]
     #[inline(always)]
-    pub fn endepout0_ep0status(&mut self) -> ENDEPOUT0_EP0STATUS_W {
+    pub fn endepout0_ep0status(&mut self) -> ENDEPOUT0_EP0STATUS_W<'_> {
         ENDEPOUT0_EP0STATUS_W { w: self }
     }
     #[doc = "Bit 4 - Shortcut between ENDEPOUT\\[0\\]
 event and EP0RCVOUT task"]
     #[inline(always)]
-    pub fn endepout0_ep0rcvout(&mut self) -> ENDEPOUT0_EP0RCVOUT_W {
+    pub fn endepout0_ep0rcvout(&mut self) -> ENDEPOUT0_EP0RCVOUT_W<'_> {
         ENDEPOUT0_EP0RCVOUT_W { w: self }
     }
 }

--- a/src/pac/usbd/size/epout.rs
+++ b/src/pac/usbd/size/epout.rs
@@ -35,7 +35,7 @@ impl R {
 impl W {
     #[doc = "Bits 0:6 - Number of bytes received last in the data stage of this OUT endpoint"]
     #[inline(always)]
-    pub fn size(&mut self) -> SIZE_W {
+    pub fn size(&mut self) -> SIZE_W<'_> {
         SIZE_W { w: self }
     }
 }

--- a/src/pac/usbd/tasks_dpdmdrive.rs
+++ b/src/pac/usbd/tasks_dpdmdrive.rs
@@ -33,7 +33,7 @@ impl<'a> TASKS_DPDMDRIVE_W<'a> {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn tasks_dpdmdrive(&mut self) -> TASKS_DPDMDRIVE_W {
+    pub fn tasks_dpdmdrive(&mut self) -> TASKS_DPDMDRIVE_W<'_> {
         TASKS_DPDMDRIVE_W { w: self }
     }
 }

--- a/src/pac/usbd/tasks_dpdmnodrive.rs
+++ b/src/pac/usbd/tasks_dpdmnodrive.rs
@@ -33,7 +33,7 @@ impl<'a> TASKS_DPDMNODRIVE_W<'a> {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn tasks_dpdmnodrive(&mut self) -> TASKS_DPDMNODRIVE_W {
+    pub fn tasks_dpdmnodrive(&mut self) -> TASKS_DPDMNODRIVE_W<'_> {
         TASKS_DPDMNODRIVE_W { w: self }
     }
 }

--- a/src/pac/usbd/tasks_ep0rcvout.rs
+++ b/src/pac/usbd/tasks_ep0rcvout.rs
@@ -33,7 +33,7 @@ impl<'a> TASKS_EP0RCVOUT_W<'a> {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn tasks_ep0rcvout(&mut self) -> TASKS_EP0RCVOUT_W {
+    pub fn tasks_ep0rcvout(&mut self) -> TASKS_EP0RCVOUT_W<'_> {
         TASKS_EP0RCVOUT_W { w: self }
     }
 }

--- a/src/pac/usbd/tasks_ep0stall.rs
+++ b/src/pac/usbd/tasks_ep0stall.rs
@@ -33,7 +33,7 @@ impl<'a> TASKS_EP0STALL_W<'a> {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn tasks_ep0stall(&mut self) -> TASKS_EP0STALL_W {
+    pub fn tasks_ep0stall(&mut self) -> TASKS_EP0STALL_W<'_> {
         TASKS_EP0STALL_W { w: self }
     }
 }

--- a/src/pac/usbd/tasks_ep0status.rs
+++ b/src/pac/usbd/tasks_ep0status.rs
@@ -33,7 +33,7 @@ impl<'a> TASKS_EP0STATUS_W<'a> {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn tasks_ep0status(&mut self) -> TASKS_EP0STATUS_W {
+    pub fn tasks_ep0status(&mut self) -> TASKS_EP0STATUS_W<'_> {
         TASKS_EP0STATUS_W { w: self }
     }
 }

--- a/src/pac/usbd/tasks_startepin.rs
+++ b/src/pac/usbd/tasks_startepin.rs
@@ -34,7 +34,7 @@ impl<'a> TASKS_STARTEPIN_W<'a> {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn tasks_startepin(&mut self) -> TASKS_STARTEPIN_W {
+    pub fn tasks_startepin(&mut self) -> TASKS_STARTEPIN_W<'_> {
         TASKS_STARTEPIN_W { w: self }
     }
 }

--- a/src/pac/usbd/tasks_startepout.rs
+++ b/src/pac/usbd/tasks_startepout.rs
@@ -34,7 +34,7 @@ impl<'a> TASKS_STARTEPOUT_W<'a> {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn tasks_startepout(&mut self) -> TASKS_STARTEPOUT_W {
+    pub fn tasks_startepout(&mut self) -> TASKS_STARTEPOUT_W<'_> {
         TASKS_STARTEPOUT_W { w: self }
     }
 }

--- a/src/pac/usbd/tasks_startisoin.rs
+++ b/src/pac/usbd/tasks_startisoin.rs
@@ -33,7 +33,7 @@ impl<'a> TASKS_STARTISOIN_W<'a> {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn tasks_startisoin(&mut self) -> TASKS_STARTISOIN_W {
+    pub fn tasks_startisoin(&mut self) -> TASKS_STARTISOIN_W<'_> {
         TASKS_STARTISOIN_W { w: self }
     }
 }

--- a/src/pac/usbd/tasks_startisoout.rs
+++ b/src/pac/usbd/tasks_startisoout.rs
@@ -33,7 +33,7 @@ impl<'a> TASKS_STARTISOOUT_W<'a> {
 impl W {
     #[doc = "Bit 0"]
     #[inline(always)]
-    pub fn tasks_startisoout(&mut self) -> TASKS_STARTISOOUT_W {
+    pub fn tasks_startisoout(&mut self) -> TASKS_STARTISOOUT_W<'_> {
         TASKS_STARTISOOUT_W { w: self }
     }
 }

--- a/src/pac/usbd/usbpullup.rs
+++ b/src/pac/usbd/usbpullup.rs
@@ -95,7 +95,7 @@ impl R {
 impl W {
     #[doc = "Bit 0 - Control of the USB pull-up on the D+ line"]
     #[inline(always)]
-    pub fn connect(&mut self) -> CONNECT_W {
+    pub fn connect(&mut self) -> CONNECT_W<'_> {
         CONNECT_W { w: self }
     }
 }


### PR DESCRIPTION
This PR was generated by running `cargo fix` and removing the top-level TODO.

It seems the `pac` module is generated, so maybe it's preferrable to regenerate it, but I didn't find instructions or sources from which to regenerate it.